### PR TITLE
DOC: Fix small spelling mistake in style docs

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, the cell's style depends only on it's own value.\n",
+    "In this case, the cell's style depends only on its own value.\n",
     "That means we should use the `Styler.applymap` method which works elementwise."
    ]
   },


### PR DESCRIPTION
This pull request fixes a small spelling mistake in the pandas style user guide.

I believe this change does not justify a whatsnew entry, since it is extremely small. It does not refer to a particular issue on GitHub.